### PR TITLE
CLI improvements

### DIFF
--- a/src/icewatch/geocode_facilities.py
+++ b/src/icewatch/geocode_facilities.py
@@ -5,6 +5,7 @@ Geocode facilities from a JSON file using OpenStreetMap Nominatim, with caching.
 
 import argparse
 import json
+import logging
 import os
 import time
 from datetime import datetime
@@ -15,6 +16,12 @@ import requests
 CACHE_FILENAME = "geocode_cache.json"
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 USER_AGENT = "icewatch/1.0 (collective@lockdown.systems)"
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 
 def load_json(path: Path | str) -> dict:
@@ -95,11 +102,11 @@ def main():
     )
     cache_path = args.cache or str(input_path.parent / CACHE_FILENAME)
 
-    print(f"Loading facilities from: {input_path}")
+    logger.info(f"Loading facilities from: {input_path}")
     data = load_json(input_path)
     facilities = data.get("facilities", [])
 
-    print(f"Loading geocode cache from: {cache_path}")
+    logger.info(f"Loading geocode cache from: {cache_path}")
     cache = load_cache(cache_path)
 
     session = requests.Session()
@@ -107,20 +114,22 @@ def main():
     for i, facility in enumerate(facilities):
         address = build_address(facility)
         if not address:
-            print(f"[{i + 1}/{len(facilities)}] No address for facility, skipping.")
+            logger.info(
+                f"[{i + 1}/{len(facilities)}] No address for facility, skipping."
+            )
             facility["latitude"] = None
             facility["longitude"] = None
             continue
         if address in cache and cache[address] is not None:
             result = cache[address]
-            print(f"[{i + 1}/{len(facilities)}] Cached: {address} -> {result}")
+            logger.info(f"[{i + 1}/{len(facilities)}] Cached: {address} -> {result}")
         else:
-            print(f"[{i + 1}/{len(facilities)}] Geocoding: {address}")
+            logger.info(f"[{i + 1}/{len(facilities)}] Geocoding: {address}")
             try:
                 result = geocode_address(address, session=session)
                 time.sleep(args.delay)
             except Exception as e:
-                print(f"    Error geocoding '{address}': {e}")
+                logger.info(f"    Error geocoding '{address}': {e}")
                 result = None
             if result is not None:
                 cache[address] = result
@@ -135,16 +144,16 @@ def main():
             facility["latitude"] = None
             facility["longitude"] = None
 
-    print(f"Writing geocoded facilities to: {output_path}")
+    logger.info(f"Writing geocoded facilities to: {output_path}")
     save_json(data, output_path)
 
     if updated:
-        print(f"Updating geocode cache: {cache_path}")
+        logger.info(f"Updating geocode cache: {cache_path}")
         save_cache(cache, cache_path)
     else:
-        print("No new addresses geocoded; cache unchanged.")
+        logger.info("No new addresses geocoded; cache unchanged.")
 
-    print("Done.")
+    logger.info("Done.")
 
 
 if __name__ == "__main__":

--- a/src/icewatch/geocode_facilities.py
+++ b/src/icewatch/geocode_facilities.py
@@ -146,6 +146,7 @@ def main():
 
     logger.info(f"Writing geocoded facilities to: {output_path}")
     save_json(data, output_path)
+    print(output_path)
 
     if updated:
         logger.info(f"Updating geocode cache: {cache_path}")

--- a/src/icewatch/ice_detention_scraper.py
+++ b/src/icewatch/ice_detention_scraper.py
@@ -515,7 +515,11 @@ Examples:
             logger.error(f"File not found: {args.extract_from_file}")
             sys.exit(1)
 
-        if facilities_data := extract_facilities_data(args.extract_from_file):
+        # Extract date from the filename
+        source_date = extract_date_from_filename(args.extract_from_file)
+        if facilities_data := extract_facilities_data(
+            args.extract_from_file, source_date
+        ):
             if json_filepath := save_facilities_json(facilities_data, args.output_dir):
                 logger.info("JSON extraction completed successfully!")
                 print(json_filepath)

--- a/src/icewatch/ice_detention_scraper.py
+++ b/src/icewatch/ice_detention_scraper.py
@@ -296,7 +296,9 @@ def download_ice_detention_stats(
         return None, None
 
 
-def extract_facilities_data(filepath, source_date=None):
+def extract_facilities_data(
+    filepath: str, source_date: str | None = None
+) -> dict | None:
     """
     Extract facilities data from the "Facilities FY25" tab and convert to JSON.
 
@@ -353,11 +355,10 @@ def extract_facilities_data(filepath, source_date=None):
         # Convert to list of dictionaries
         facilities_data = []
         for index, row in df.iterrows():
-            facility = {}
+            facility: dict[str, str | float | None] = {}
             for col in expected_columns.keys():
                 if col in df.columns:
                     value = row[col]
-                    # Convert NaN to None for JSON serialization
                     if pd.isna(value):
                         facility[col] = None
                     else:
@@ -385,7 +386,7 @@ def extract_facilities_data(filepath, source_date=None):
         return None
 
 
-def save_facilities_json(data, output_dir="data"):
+def save_facilities_json(data: dict, output_dir: str = "data") -> str | None:
     """
     Save facilities data to a JSON file.
 
@@ -419,7 +420,7 @@ def save_facilities_json(data, output_dir="data"):
         return None
 
 
-def verify_download(filepath):
+def verify_download(filepath: str) -> bool:
     """
     Verify that the downloaded file is a valid Excel file.
 


### PR DESCRIPTION
This is a small quality of life improvement. When working with the scripts locally, I currently copy and paste the printed out file path to ensure I interact with the correct file. This PR ensures that all process information is printed to stderr and the file paths are printed to stdout. This helps with the following types of workflows:

```shell
# quiet logs and only show produced file
icewatch scrape 2> /dev/null # quiet logs and only show produced file

# chain commands
icewatch geocode --input $(icewatch scrape --extract-json)

# set environment variables
XLSX_FILE=$(icewatch scrape)
```