### PR TITLE
Set default value for formatted_date

### DIFF
--- a/src/icewatch/render_facilities_map.py
+++ b/src/icewatch/render_facilities_map.py
@@ -149,6 +149,7 @@ def render_html(
     # Build the header stats with last checked date
     header_stats = f'<div class="stat-item"><strong>{total_people:,}</strong> people in ICE detention</div>'
     header_stats += f'<div class="stat-item"><strong>{pct_noncriminal}</strong> without criminal records</div>'
+    formatted_date = datetime.now().strftime("%Y-%m-%d")
     if last_checked_date:
         # Format extraction date nicely (remove time if present)
         try:


### PR DESCRIPTION
The past few runs failed because the variable `formatted_date` was [unbounded](
https://github.com/lockdown-systems/icewatch/actions/runs/16829890014/job/47674778626#step:8:24). This PR just gives a default value of today to `formatted_date`.