### PR TITLE
Add Mapbox geocoding API option

### DIFF
--- a/src/icewatch/geocode/__init__.py
+++ b/src/icewatch/geocode/__init__.py
@@ -1,4 +1,29 @@
-from icewatch.geocode.nomination import geocode_address
+import logging
+import os
+from functools import partial
+from typing import Callable
+
+import requests
+
+from icewatch.geocode.mapbox import query_mapbox
+from icewatch.geocode.types import Coordinates
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+geocode_address: Callable[[str, requests.Session | None], Coordinates | None]
+
+MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
+if MAPBOX_ACCESS_TOKEN:
+    geocode_address = partial(query_mapbox, MAPBOX_ACCESS_TOKEN)
+    logger.info("MAPBOX_ACCESS_TOKEN found, using Mapbox api")
+else:
+    from icewatch.geocode.nomination import geocode_address
+
+    logger.warning("No MAPBOX_ACCESS_TOKEN found, falling back to nomination")
 
 
 __all__ = ["geocode_address"]

--- a/src/icewatch/geocode/__init__.py
+++ b/src/icewatch/geocode/__init__.py
@@ -1,0 +1,4 @@
+from icewatch.geocode.nomination import geocode_address
+
+
+__all__ = ["geocode_address"]

--- a/src/icewatch/geocode/mapbox.py
+++ b/src/icewatch/geocode/mapbox.py
@@ -1,0 +1,30 @@
+from icewatch.geocode.types import Coordinates
+
+import requests
+
+
+MAPBOX_URL = "https://api.mapbox.com/search/geocode/v6/forward"
+
+
+def query_mapbox(
+    access_token: str,
+    address: str,
+    session: requests.Session | None = None,
+) -> Coordinates | None:
+    params: dict[str, str | int] = {
+        "q": address,
+        "access_token": access_token,
+        "limit": 1,
+    }
+
+    s = session or requests.Session()
+    response = s.get(MAPBOX_URL, params=params)
+    response.raise_for_status()
+    if result := response.json():
+        feature = result["features"][0]
+        coordinates = feature["properties"]["coordinates"]
+        return {
+            "lat": float(coordinates["latitude"]),
+            "lon": float(coordinates["longitude"]),
+        }
+    return None

--- a/src/icewatch/geocode/nomination.py
+++ b/src/icewatch/geocode/nomination.py
@@ -1,0 +1,22 @@
+import requests
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+USER_AGENT = "icewatch/1.0 (collective@lockdown.systems)"
+
+
+def geocode_address(
+    address: str, session: requests.Session | None = None
+) -> dict | None:
+    params = {
+        "q": address,
+        "format": "json",
+        "limit": "1",  # set as string to match request param type
+    }
+    headers = {"User-Agent": USER_AGENT}
+    s = session or requests.Session()
+    response = s.get(NOMINATIM_URL, params=params, headers=headers, timeout=15)
+    response.raise_for_status()
+    results = response.json()
+    if results:
+        return {"lat": float(results[0]["lat"]), "lon": float(results[0]["lon"])}
+    return None

--- a/src/icewatch/geocode/nomination.py
+++ b/src/icewatch/geocode/nomination.py
@@ -1,4 +1,5 @@
 import requests
+from icewatch.geocode.types import Coordinates
 
 NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 USER_AGENT = "icewatch/1.0 (collective@lockdown.systems)"
@@ -6,7 +7,7 @@ USER_AGENT = "icewatch/1.0 (collective@lockdown.systems)"
 
 def geocode_address(
     address: str, session: requests.Session | None = None
-) -> dict | None:
+) -> Coordinates | None:
     params = {
         "q": address,
         "format": "json",

--- a/src/icewatch/geocode/types.py
+++ b/src/icewatch/geocode/types.py
@@ -1,0 +1,6 @@
+from typing import TypedDict
+
+
+class Coordinates(TypedDict):
+    lat: float
+    lon: float

--- a/src/icewatch/geocode_facilities.py
+++ b/src/icewatch/geocode_facilities.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Geocode facilities from a JSON file using OpenStreetMap Nominatim, with caching.
+Geocode facilities from a JSON file with caching.
 """
 
 import argparse
@@ -13,9 +13,9 @@ from pathlib import Path
 
 import requests
 
+from icewatch.geocode import geocode_address
+
 CACHE_FILENAME = "geocode_cache.json"
-NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
-USER_AGENT = "icewatch/1.0 (collective@lockdown.systems)"
 
 # Configure logging
 logging.basicConfig(
@@ -54,24 +54,6 @@ def build_address(facility: dict) -> str:
         str(facility.get("Zip", "")),
     ]
     return ", ".join([str(p).strip() for p in parts if p and str(p).strip()])
-
-
-def geocode_address(
-    address: str, session: requests.Session | None = None
-) -> dict | None:
-    params = {
-        "q": address,
-        "format": "json",
-        "limit": "1",  # set as string to match request param type
-    }
-    headers = {"User-Agent": USER_AGENT}
-    s = session or requests.Session()
-    response = s.get(NOMINATIM_URL, params=params, headers=headers, timeout=15)
-    response.raise_for_status()
-    results = response.json()
-    if results:
-        return {"lat": float(results[0]["lat"]), "lon": float(results[0]["lon"])}
-    return None
 
 
 def main():


### PR DESCRIPTION
Followup to discussion from [#38](https://github.com/lockdown-systems/icewatch/pull/38#issuecomment-3181868726)

This will check if an environment variable `MAPBOX_ACCESS_TOKEN` is set and opt to using Mapbox's geocoding API over nomination's API.