### PR TITLE
Add (minor): add mastodon attribution and verification

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,13 +4,11 @@
     <meta charset="utf-8" />
     <title>ICE Detention Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="fediverse:creator" content="@lockdownsystems@infosec.exchange">
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     />
     <link rel="stylesheet" href="css/styles.css" />
-    <link href="https://infosec.exchange/@lockdownsystems" rel="me">
     <script
       defer
       data-domain="watchice.org"

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,11 +4,13 @@
     <meta charset="utf-8" />
     <title>ICE Detention Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fediverse:creator" content="@lockdownsystems@infosec.exchange">
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     />
     <link rel="stylesheet" href="css/styles.css" />
+    <link href="https://infosec.exchange/@lockdownsystems" rel="me">
     <script
       defer
       data-domain="watchice.org"

--- a/src/icewatch/templates/map.html
+++ b/src/icewatch/templates/map.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <title>ICE Detention Map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="fediverse:creator" content="@lockdownsystems@infosec.exchange">
+    <link href="https://infosec.exchange/@lockdownsystems" rel="me">
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"


### PR DESCRIPTION
This will add an attribution to the Lockdown Systems Mastodon account each time a link to this website is posted on the Fediverse, and will allow verification of the website on the Lockdown Systems Mastodon account.